### PR TITLE
Fixed logic for archiving users

### DIFF
--- a/backend/app/routes/auth.py
+++ b/backend/app/routes/auth.py
@@ -66,6 +66,18 @@ async def auth_callback(code: str):
         # Check to see if the user_info contains the email field
         if "email" not in user_info:
           return RedirectResponse(url="/?alert=missing_email")
+        
+        try:
+          with get_session() as session:
+              statement = select(User).where(User.email == user_info["email"])
+              db_user = session.exec(statement).first()
+              if db_user and db_user.archived == 1:
+                  # User is archived, do not log in
+                  return RedirectResponse(url="/?alert=archived_user")
+        except Exception as e:
+          # Optionally handle DB errors
+          return RedirectResponse(url="/?alert=database_error")
+            
         response = RedirectResponse(url="/?alert=login_successful")
         # Set the access token in the cookies
         response.set_cookie(
@@ -158,9 +170,10 @@ async def auth_me(request: Request, response: Response):
                     logger.info(
                       f"User with email '{db_user.email}' is archived. Cannot authenticate them!"
                     )
+                    response.delete_cookie("access_token")
                     return {
                       "status": "failure",
-                      "message": "Failed to fetch user info",
+                      "message": "User is archived. Login prevented!",
                       "details": str(e),
                     }
 

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -49,6 +49,18 @@ const Home = () => {
           'No email associated with the login method you chose, please use a different method.',
         );
         break;
+      case 'archived_user':
+        alert = messageTemplate(
+          'danger',
+          'Your account has been archived and cannot be used to log in. Please contact support if you believe this is an error.',
+        );
+        break;
+      case 'database_error':
+        alert = messageTemplate(
+          'info',
+          'Failed to login due to the system being down. Please try again later!',
+        );
+        break;
       case 'invalid_userinfo_response':
         alert = messageTemplate(
           'danger',


### PR DESCRIPTION
- In the callback function, we check if the email is associated with a archived user, if they are, we don't give them a cookie. Stopping the auth process. We also have an additional check in the /auth/me that removes the cookie if they have a cookie associated with an archived user. This handles the case when the user is already logged in, we archive them, they refresh, they should no longer be authenticated I think.
- Updated the frontend so that it indicates when a user's account is archived. I know this doesn't really follow best security standards since you're supposed to say "not found", but I think in this case, it's probably good to tell users that things are archived.