### PR TITLE
Added note to users about supcrtbl

### DIFF
--- a/frontend/src/pages/Supcrtbl/SupcrtblOnline.jsx
+++ b/frontend/src/pages/Supcrtbl/SupcrtblOnline.jsx
@@ -955,12 +955,22 @@ export default function SupcrtbOnline() {
                 <br /> Positive numbers are products and negative numbers are
                 reactants,
                 <br />
+                
                 e.g. QUARTZ {'=>'} SiO2,aq:
                 <br />
                 <code>
                   -1 QUARTZ
                   <br />1 SiO2,aq
                 </code>
+
+                <br />
+                
+                <span>
+                <strong>Note:</strong> Currently H2O doesn't appear in the drop down, so please type it in manually if you want to use it.
+                </span>
+                
+                
+                
               </label>
 
               {reactionInputs.map((input, index) => (


### PR DESCRIPTION
Basically H2O doesn't appear in the drop down for SupcrtblOnline. As a temporary fix, we'll just have a note telling users to type in H2O, which just lets them know that it is indeed a valid option for the supcrtbl binary. 

In the future though, I'm guessing one of the geochemical modeling people will add H2O as an actual row in the database.